### PR TITLE
build: Update Makefile for EdgeX 3.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 
 .PHONY: build tidy test clean docker integration-test logs
 .SILENT: get-consul-acl-token
-GO=CGO_ENABLED=1 go
+GO=CGO_ENABLED=0 go
 
 # VERSION file is not needed for local development, In the CI/CD pipeline, a temporary VERSION file is written
 # if you need a specific version, just override below
@@ -13,7 +13,7 @@ MSVERSION=$(shell cat ./VERSION 2>/dev/null || echo 0.0.0)
 
 # This pulls the version of the SDK from the go.mod file. If the SDK is the only required module,
 # it must first remove the word 'required' so the offset of $2 is the same if there are multiple required modules
-SDKVERSION=$(shell cat ./go.mod | grep 'github.com/edgexfoundry/app-functions-sdk-go/v2 v' | sed 's/require//g' | awk '{print $$2}')
+SDKVERSION=$(shell cat ./go.mod | grep 'github.com/edgexfoundry/app-functions-sdk-go/v3 v' | sed 's/require//g' | awk '{print $$2}')
 
 PROJECT=aicsd
 
@@ -43,7 +43,7 @@ SVCS=$(filter-out pkg/. tools/. integration-tests/. ms-web-ui/., $(DIRS))
 # Linux needs no file extension, or prefix unless x-compiling for windows
 EXT=
 
-GOFLAGS=-ldflags "-X github.com/edgexfoundry/app-functions-sdk-go/v2/internal.SDKVersion=$(SDKVERSION) -X github.com/edgexfoundry/app-functions-sdk-go/v2/internal.ApplicationVersion=$(MSVERSION)" -buildvcs=false
+GOFLAGS=-ldflags "-X github.com/edgexfoundry/app-functions-sdk-go/v3/internal.SDKVersion=$(SDKVERSION) -X github.com/edgexfoundry/app-functions-sdk-go/v3/internal.ApplicationVersion=$(MSVERSION)" -buildvcs=false
 
 GIT_SHA=$(shell git rev-parse HEAD)
 


### PR DESCRIPTION
Closes: #41

## PR Checklist

## Author Mandatory (to be filled by PR Author/Submitter)

### CODE MAINTAINABILITY

- [x] **_Commit Message meets guidelines as indicated in the URL\*_**
    - <https://github.com/intel/AiCSD/blob/main/.github/CONTRIBUTING.md>
- [ ] Tests for the changes have been added (required for bug fixes / features). **If not, state why not**
- [ ] Added labels (these are git labels such as bug or enhancement)
- [ ] For any API changes or service changes, updates to the documentation were made (Swagger APIs & GitHub Docs). **If not, state why not**
- [ ] **_Every commit is a single defect fix and does not mix feature addition or changes\*_**

### What are the steps to test this PR contribution?

How does a reviewer know it works?

This PR contains breaking changes that will not be tested until the rest of the 3.1 upgrades happen.
<!-- For example, "1. Run `make integration-test` ... observe no errors." -->
<!-- For example, "Open localhost:4200 and confirm view looks like this screenshot below" -->

Are there any special instructions beyond standard workflow?

<!-- For example, "This patch requires Linux or two systems to test." -->

## Maintainer Mandatory (to be filled by PR Reviewer/Approving Maintainer)

### QUALITY CHECKS

- [ ] **_Quality of code (At least one should be checked as applicable)\*_**
    - [ ] Commit Message meets guidelines
    - [ ] Code copyright is correct
    - [ ] PR changes adhere to industry practices and standards as well as domain or language specific anti-patterns
    - [ ] Adopted domain specific coding standards ([Go Coding Standards](https://go.dev/doc/effective_go))
    - [ ] Code is adequately commented and documented
    - [ ] Confusing logic is explained in comments
    - [ ] Error and exception code paths implemented correctly
    - [ ] Tracing output are minimized and logic
- [ ] **_Test coverage shows adequate coverage with required CI functional tests pass on all supported platforms\*_**
- [ ] **_Static code scan report shows zero critical issues\*_**

## Other information